### PR TITLE
Destroy existing handler on reopen

### DIFF
--- a/PlaidLink.vue
+++ b/PlaidLink.vue
@@ -54,7 +54,8 @@ export default {
   },
   data() {
     return {
-      plaid: null
+      plaid: null,
+      linkHandler: null
     }
   },
   methods: {
@@ -63,7 +64,12 @@ export default {
 
       let self = this
       if (this.plaid != null) {
-        this.plaid.create({
+        // destroy link handler to prevent stacking of iframes
+        if (this.linkHandler != null) {
+          this.linkHandler.destroy();
+          this.linkHandler = null;
+        }
+        this.linkHandler = this.plaid.create({
           clientName: this.clientName,
           env: this.env,
           isWebview: this.isWebview,
@@ -107,7 +113,8 @@ export default {
             // }
             self.onEvent(eventName, metadata)
           }
-        }).open()
+        });
+        this.linkHandler.open();
       }
     }
   },


### PR DESCRIPTION
If you close and reopen plaid link, it will keep on stacking iframes in dom. This fix destroys existing link handler before new one is created. According to plaid docs, calling destroy will make sure iframe is also removed. 
Not sure if destroy should be called onExit, but checking other implementation (like react plaid), they are doing the check before create as well.

@cyrusstoller could you please check this and give me your thoughts? Thanks!